### PR TITLE
Materialize the stream in test for failure

### DIFF
--- a/testservice-impl/src/test/scala/test/services/TestServiceImplSpec.scala
+++ b/testservice-impl/src/test/scala/test/services/TestServiceImplSpec.scala
@@ -31,10 +31,12 @@ class TestServiceImplSpec extends AsyncWordSpec with MustMatchers {
 
       //string 'fail' should throw an exception
       val eventualSource2 = client.test().invoke(LookupQuery("fail"))
+      val streamResult = eventualSource2.flatMap(_.runWith(Sink.ignore))(system.dispatcher)
 
-      ScalaFutures.whenReady(eventualSource2.failed, Timeout(Span(5, Seconds))) { e =>
+      ScalaFutures.whenReady(streamResult.failed, Timeout(Span(5, Seconds))) { e =>
         e mustBe a[Throwable]
       }
+
 
     }
   }


### PR DESCRIPTION
The test passes with this change.

The explanation is that in this scenario, the streaming connection is established successfully (so the `Future` returned from `invoke` completes successfully with a `Source`) before an application-level failure occurs in the stream processing (which causes the stream itself to fail).